### PR TITLE
Show all messages and differentiate between severity (error vs warn)

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -8,8 +8,6 @@ if (nodeModulesPath) {
 }
 var configFile = args[2];
 
-var MAX_WARNINGS = 7;
-
 var CLIEngine = require('eslint').CLIEngine;
 var options = {};
 if (configFile) {
@@ -24,7 +22,6 @@ console.log(format(report.results));
 
 function format(results) {
   var lines = [];
-  var title = 'error';
 
   function numberWang(wangaNumb) {
     var thatsNumberWang = 7 - wangaNumb;
@@ -44,37 +41,31 @@ function format(results) {
   var messages = results[0].messages;
   var errorCount = results[0].errorCount || 0;
   var warningCount = results[0].warningCount || 0;
-  var count = 0;
 
-  errorCount += warningCount;
-
-  if (errorCount) {
-    if (errorCount > 1) {
-      title += 's';
-    }
+  if (errorCount || warningCount) {
 
     messages.forEach(function(error) {
-      if (count >= MAX_WARNINGS) {
-        return;
-      }
       var ruleId = error.ruleId ? ' (' + error.ruleId + ')' : '';
+      var severity = (error.severity === 1 ? 'Warn ' : 'Error');
 
       lines.push([
+        '\t',
+        severity,
         numberWang((error.line + error.column.toString()).length),
         error.line + ',' + error.column + ':',
         error.message + ruleId
       ].join(' '));
-
-      count++;
     });
 
     lines.push('');
-    lines.push(
-      '✗ ' + count + ' ' + title +
-      ', double-click above, [F4] for next, [shift-F4] for previous.'
+    lines.push('✗ ' +
+      errorCount + ' ' + (errorCount === 1 ? 'error' : 'errors') + ', ' +
+      warningCount + ' ' + (warningCount === 1 ? 'warning' : 'warnings'));
+    lines.push('');
+    lines.push('Double-click on lines to jump to location, [F4] for next, [shift-F4] for previous.'
     );
   } else {
-    lines.push('✓ 0 errors, [esc] to hide.');
+    lines.push('✓ 0 errors and warnings, [esc] to hide.');
   }
 
   lines.push('');


### PR DESCRIPTION
@polygonplanet 

I'd like to know if a message is a warning or error (because errors will fail our build).  Here's a change I made to show it.  The current output was probably tailored to what you want, but if you find this useful, please consider it for merging.  Thank you.
### Changes

Output shows "Warn" or "Error" before message.  The warning and error counts are separated.  All messages are shown.

![image](https://cloud.githubusercontent.com/assets/1372234/17942932/4e80035c-69ee-11e6-911a-6b7f97616311.png)
