### PR TITLE
Remove possible erroneous Tools mnemonic

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,7 +1,6 @@
 [
   {
     "caption": "Tools",
-    "mnemonic": "t",
     "id": "tools",
     "children": [
       {


### PR DESCRIPTION
Similar to https://github.com/uipoet/sublime-jshint/pull/78/commits/61b3a5c7f29865945f7447b45fa403348e2eafd1?diff=split and explained [here](https://gist.github.com/saildata/9733ff2d647e332d3bbb) or [here](http://dufferzafar.github.io/2015/06/15/fixing-mnemonic-not-found-bug-in-sublime-text/).

I really appreciate the package!

