### PR TITLE
Show wang and error position only if they are set

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -60,14 +60,17 @@ function format(results) {
     messages.forEach(function(error) {
       var ruleId = error.ruleId ? ' (' + error.ruleId + ')' : '';
       var severity = (error.severity === 1 ? 'Warn ' : 'Error');
+      var hasPosition = (error.line !== undefined && error.column !== undefined);
+      var messageParts = ['\t', severity];
 
-      lines.push([
-        '\t',
-        severity,
-        numberWang((error.line + error.column.toString()).length),
-        error.line + ',' + error.column + ':',
-        error.message + ruleId
-      ].join(' '));
+      if (hasPosition) {
+        messageParts.push(numberWang((error.line + error.column.toString()).length));
+        messageParts.push(error.line + ',' + error.column + ':');
+      }
+
+      messageParts.push(error.message + ruleId);
+
+      lines.push(messageParts.join(' '));
     });
 
     lines.push('');


### PR DESCRIPTION
Fixes #14 

Output after changes:

```
[ESLint: /Users/tsuriga/code/test/.eslintrc.js]

	 Warn  File ignored by default.  Use a negated ignore pattern (like "--ignore-pattern '!<relative/path/to/filename>'") to override.

✗ 0 errors, 1 warning

Double-click on lines to jump to location, [F4] for next, [shift-F4] for previous.

[Finished in 0.3s]
```