### PR TITLE
Fix to use current working directory's node_modules/eslint in an active project #20 

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -13,7 +13,7 @@ if (nodeModulesPath) {
 }
 var configFile = args[2];
 
-var eslintPath = path.join(targetDir, 'node_modules', 'eslint');
+var eslintPath = require.resolve('eslint', {paths: [targetDir]});
 var eslint;
 if (fs.existsSync(eslintPath)) {
   eslint = require(eslintPath);


### PR DESCRIPTION
Fix to use current working directory's node_modules/eslint in an active project #20 
**Notes**:
- This make the plugin depend on Node 8.9.0 or above
- This was previously solve in #11 but it's appear to doesn't work for all (At least not for me nor #20).
- I still think the original approach should work [bcec646]. If we look deeper this approach (That work for me) just split the require in two explicit steps, that were supposed to happen as one
  - In fact, in the future, we can remove the `if (fs.existsSync(eslintPath)) {` because the `require.resolve` will seek from closest to global