### PR TITLE
Fallback / Compatibility version, under Node 8.9.0 (Use global lib)

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var args = process.argv.slice(2);
 
+var minNodeVersion = ["8","9","0"];
 var targetPath = args[0];
 var targetDir = path.dirname(targetPath);
 
@@ -12,16 +13,26 @@ if (nodeModulesPath) {
   module.paths.push(nodeModulesPath);
 }
 var configFile = args[2];
+var nodeVersion = (process.version+"").replace(/v/gi, "").split(".");
+var isNodeMinVersion = false;
 
-var eslintPath = require.resolve('eslint', {paths: [targetDir]});
-var eslint;
-if (fs.existsSync(eslintPath)) {
-  eslint = require(eslintPath);
-} else {
-  eslint = require('eslint');
+if(nodeVersion.length===3){
+  minNodeVersion.every(function(itm, idx){
+    var isGreater = (nodeVersion[idx]*1 > itm*1)?true:false;
+    var isEqual = (itm*1 == nodeVersion[idx]*1)?true:false;
+
+    isNodeMinVersion = (isGreater || isEqual);
+    return (!isGreater && isEqual);
+  });
 }
 
+var eslintPath = (isNodeMinVersion)
+  ? require.resolve('eslint', {paths: [targetDir]})
+  : require.resolve('eslint');
+
+var eslint = require(eslintPath);
 var CLIEngine = eslint.CLIEngine;
+
 var options = {};
 if (configFile) {
   options.configFile = configFile;


### PR DESCRIPTION
Fallback / Compatibility version, that use the global library by default if is under the node version we support. Based on discussion in #21 
This will cause the use of global lib if the node version is under 8.9.0, otherwise will take the closest version