### PR TITLE
Enables the use of the global eslint module

### DIFF
--- a/linter.js
+++ b/linter.js
@@ -16,7 +16,7 @@ var configFile = args[2];
 var isNodeMinVersion = checkNodeMinVersion(process.version);
 
 var eslintPath = (isNodeMinVersion)
-  ? require.resolve('eslint', {paths: [targetDir]})
+  ? require.resolve('eslint', {paths: [targetDir, nodeModulesPath]})
   : require.resolve('eslint');
 
 var eslint = require(eslintPath);


### PR DESCRIPTION
I had this same problem (https://github.com/polygonplanet/sublime-text-eslint/pull/21#commitcomment-30648166)

If i don't add the nodeModulesPath to the require, the loader cannot find the eslint module.

I did not fully test this, but it should work.